### PR TITLE
Deploy via DigitalOcean App Platform (Docker)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -115,13 +115,10 @@ services:
         value: --mainnet
 
       # --- Optional but strongly recommended in production ---
-      - key: LOG_FORMAT
-        # JSON-per-line so DO's log panel indexes fields cleanly.
-        value: json
-      - key: LOG_FILE
-        # Kill the rotating file handler — gunicorn's stdout/stderr is
-        # what App Platform captures; a second sink just costs disk.
-        value: /dev/null
+      # LOG_FORMAT=json and LOG_FILE=/dev/null are baked into the
+      # Dockerfile as defaults — App Platform captures gunicorn stdout
+      # and indexes the JSON fields. Override here only if you want
+      # plain-text logs or a different sink.
       - key: LOG_LEVEL
         value: INFO
       - key: COLLATERAL_THROTTLE_RATE

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,162 @@
+# DigitalOcean App Platform spec.
+#
+# Apply via:
+#   doctl apps create --spec .do/app.yaml          # first time
+#   doctl apps update <app-id> --spec .do/app.yaml # subsequent edits
+#
+# Push-to-main → DO rebuilds the Docker image and rolls it out. No SSH.
+#
+# Operator setup checklist lives in docs/DEPLOY.md. The short version:
+# fill in the three SECRET env vars (DJANGO_SECRET_KEY, SKEY_CONTENTS,
+# VKEY_CONTENTS), point the GitHub repo, set ALLOWED_HOSTS to the
+# DO-issued hostname (and your custom domain if applicable), and
+# `doctl apps create`.
+
+name: collateral-provider
+
+# One region is fine for a small service; pick whichever is closest to
+# the majority of your users / your Koios endpoint. nyc / sfo / fra / blr
+# / sgp / ams / syd / tor are all valid.
+region: nyc
+
+services:
+  - name: web
+    # Build the image from the repo's Dockerfile. App Platform watches
+    # the deploy_on_push branch and triggers a rebuild on every push.
+    dockerfile_path: Dockerfile
+
+    github:
+      repo: logical-mechanism/Collateral-Provider
+      branch: main
+      deploy_on_push: true
+
+    # Smallest paid tier. The service is light (one upstream, ed25519
+    # signatures, 16 KiB max payload), so basic-xxs is enough — bump
+    # only if /metrics shows actual saturation.
+    instance_size_slug: basic-xxs
+    instance_count: 1
+
+    http_port: 8080
+
+    # /healthz is unthrottled, returns 503 if signing keys become
+    # unreadable, and 200 otherwise. App Platform routes traffic to the
+    # instance only once this returns 200.
+    health_check:
+      http_path: /healthz
+      initial_delay_seconds: 10
+      period_seconds: 10
+      timeout_seconds: 3
+      success_threshold: 1
+      failure_threshold: 3
+
+    # Per-environment routing: this service is at the apex domain. Add
+    # a `domains:` block at the app level (below) for a custom domain.
+    routes:
+      - path: /
+
+    # === Environment variables ===
+    #
+    # Sensitive values are marked SECRET (encrypted at rest, never
+    # printed in logs). Plain values are GENERAL. Most of these are
+    # documented in collateral_provider/sample.env.
+    envs:
+      # --- Required: identity + signing ---
+      - key: PKH
+        scope: RUN_AND_BUILD_TIME
+        value: REPLACE_WITH_YOUR_COLLATERAL_PKH
+      - key: DJANGO_SECRET_KEY
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_WITH_A_50_CHAR_RANDOM_STRING
+
+      # Signing keys: paste the entire JSON content of payment.skey /
+      # payment.vkey here. The container's entrypoint writes them to
+      # /run/keys/ at boot and points SKEY_PATH / VKEY_PATH there.
+      # If you'd rather mount a volume, leave these empty and set
+      # SKEY_PATH / VKEY_PATH directly to point into the volume mount.
+      - key: SKEY_CONTENTS
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_WITH_PAYMENT_SKEY_JSON_CONTENT
+      - key: VKEY_CONTENTS
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_WITH_PAYMENT_VKEY_JSON_CONTENT
+
+      # --- Required: production posture ---
+      - key: ENVIRONMENT
+        value: production
+      - key: ALLOWED_HOSTS
+        # Comma-separated. Always include the DO-issued hostname plus
+        # any custom domain. Find the DO hostname in the App Platform
+        # web console under "Domains".
+        value: REPLACE_WITH_DO_HOSTNAME,your-custom-domain.example
+      - key: TRUSTED_PROXY_IPS
+        # DO App Platform's HTTP router connects to the container from
+        # a private IP — the exact address rotates and isn't pinned in
+        # any public docs. Listing the RFC1918 ranges is the right move
+        # here: the container is never directly reachable from the
+        # public internet, so any "private peer" must be the platform's
+        # router. CIDR support added specifically for this case.
+        value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+
+      # --- Required: per-network configuration ---
+      - key: PREPROD_TXID
+        value: REPLACE_WITH_PREPROD_COLLATERAL_TXID
+      - key: PREPROD_TXIDX
+        value: "0"
+      - key: PREPROD_NETWORK
+        value: --testnet-magic 1
+      - key: MAINNET_TXID
+        value: REPLACE_WITH_MAINNET_COLLATERAL_TXID
+      - key: MAINNET_TXIDX
+        value: "0"
+      - key: MAINNET_NETWORK
+        value: --mainnet
+
+      # --- Optional but strongly recommended in production ---
+      - key: LOG_FORMAT
+        # JSON-per-line so DO's log panel indexes fields cleanly.
+        value: json
+      - key: LOG_FILE
+        # Kill the rotating file handler — gunicorn's stdout/stderr is
+        # what App Platform captures; a second sink just costs disk.
+        value: /dev/null
+      - key: LOG_LEVEL
+        value: INFO
+      - key: COLLATERAL_THROTTLE_RATE
+        value: 60/min
+
+      # /metrics is off by default. Turn it on only if you have a
+      # scraper IP to allowlist; leaving it off keeps the URL 404'd.
+      # - key: METRICS_ENABLED
+      #   value: "True"
+      # - key: METRICS_ALLOW_IPS
+      #   value: 127.0.0.1,::1,YOUR_SCRAPER_IP
+
+      # --- Hot-reloadable data files ---
+      # bans.json and known.hosts.json default to in-image paths, which
+      # means edits require a redeploy. To keep the hot-reload property,
+      # uncomment the volume below and the two PATH overrides:
+      # - key: BANS_PATH
+      #   value: /data/bans.json
+      # - key: KNOWN_HOSTS_PATH
+      #   value: /data/known.hosts.json
+
+# Persistent volume for hot-reloadable config.
+#
+# DO App Platform volumes survive deploys. Mount one at /data/, edit
+# bans.json / known.hosts.json via `doctl apps console` (or by re-
+# uploading the spec with new values), and the running service will
+# pick up the changes on the next request — no restart needed.
+#
+# Skip the entire block if you're OK redeploying to change bans/hosts.
+# volumes:
+#   - name: data
+#     mount_path: /data
+#     size_gib: 1
+
+# Add a custom domain here once it's verified in the App Platform UI.
+# domains:
+#   - domain: your-custom-domain.example
+#     type: PRIMARY

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Build context: keep it small and avoid leaking local secrets.
+
+# Python build artifacts
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Local venv must not get baked in (huge + arch-specific)
+venv/
+
+# Dev-only env file — DO App Platform supplies env vars directly; if a
+# .env happens to exist on the developer's machine it would override
+# whatever DO injects, which is the opposite of what we want.
+collateral_provider/.env
+
+# Operator-curated runtime data and logs
+collateral_provider/.cache/
+collateral_provider/debug.log
+collateral_provider/debug.log.*
+collateral_provider/db.sqlite3
+collateral_provider/bans.json
+
+# Real signing keys MUST NOT enter the image. The CI dummies have the
+# same names, so the only safe rule is: never copy api/key/ at all.
+# Mount the real files via SKEY_PATH / VKEY_PATH at runtime instead.
+collateral_provider/api/key/
+
+# Git + editor noise
+.git/
+.gitignore
+.github/
+.idea/
+.vscode/
+
+# Docs/scripts that aren't needed inside the running image
+docs/
+guides/
+scripts/
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
             -e MAINNET_TXID=$ZEROS \
             -e MAINNET_TXIDX=0 \
             -e MAINNET_NETWORK=--mainnet \
+            -e LOG_FORMAT=json \
+            -e LOG_FILE=/dev/null \
             collateral-provider:ci
 
           # Give gunicorn a moment to bind. /healthz is the readiness signal.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,58 @@ jobs:
 
       - name: Audit runtime dependencies
         run: pip-audit -r requirements.txt
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: ci
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t collateral-provider:ci .
+
+      - name: Smoke test container
+        # Boot the image with synthetic env vars and the same all-zero
+        # dummy keys CI uses for the test suite, then hit /healthz and
+        # the landing page. Fails the workflow if either request 4xx/5xx's
+        # or the container dies during startup.
+        run: |
+          ZEROS="0000000000000000000000000000000000000000000000000000000000000000"
+          SKEY_JSON='{"type":"PaymentSigningKeyShelley_ed25519","description":"CI dummy — not real","cborHex":"5820'$ZEROS'"}'
+          VKEY_JSON='{"type":"PaymentVerificationKeyShelley_ed25519","description":"CI dummy — not real","cborHex":"5820'$ZEROS'"}'
+
+          docker run -d --name app -p 8080:8080 \
+            -e PKH=$ZEROS \
+            -e DJANGO_SECRET_KEY=ci-secret-key-not-for-production \
+            -e ENVIRONMENT=development \
+            -e SKEY_CONTENTS="$SKEY_JSON" \
+            -e VKEY_CONTENTS="$VKEY_JSON" \
+            -e PREPROD_TXID=$ZEROS \
+            -e PREPROD_TXIDX=0 \
+            -e "PREPROD_NETWORK=--testnet-magic 1" \
+            -e MAINNET_TXID=$ZEROS \
+            -e MAINNET_TXIDX=0 \
+            -e MAINNET_NETWORK=--mainnet \
+            collateral-provider:ci
+
+          # Give gunicorn a moment to bind. /healthz is the readiness signal.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsS http://localhost:8080/healthz > /tmp/health.json; then
+              echo "Healthcheck OK after ${i}s"
+              cat /tmp/health.json
+              break
+            fi
+            sleep 1
+            if [ "$i" = "10" ]; then
+              echo "Healthcheck never came up. Container logs:"
+              docker logs app
+              exit 1
+            fi
+          done
+
+          # Landing page should render without raising on the {% static %} tags.
+          curl -fsS http://localhost:8080/ > /dev/null
+
+          docker logs app
+          docker rm -f app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,41 @@ HTTP contract:
 
 ## [Unreleased]
 
+### Added
+
+- **Container-platform deploy shape.** [`Dockerfile`](Dockerfile),
+  [`docker-entrypoint.sh`](docker-entrypoint.sh), and
+  [`.do/app.yaml`](.do/app.yaml) bundle a one-command DigitalOcean App
+  Platform deploy: push to `main` → DO rebuilds the image and rolls it
+  out behind their TLS-terminating router. Signing keys enter the
+  runtime via `SKEY_CONTENTS` / `VKEY_CONTENTS` SECRET env vars (or a
+  mounted volume); the entrypoint materializes them to `/run/keys/`
+  (tmpfs) before exec'ing gunicorn so the existing `ApiConfig.ready()`
+  signing-key check is satisfied. Operator runbook in
+  [`docs/DEPLOY.md`](docs/DEPLOY.md).
+- **`whitenoise`** dependency for in-process static-file serving so
+  the deployed container needs no separate web server. Picked the
+  non-manifest variant — the manifest one breaks template rendering
+  whenever `collectstatic` hasn't run yet, which includes the test
+  suite.
+- **CIDR support in `TRUSTED_PROXY_IPS`.** Each entry is parsed via
+  `ipaddress.ip_network` so single hosts (`127.0.0.1`) and blocks
+  (`10.0.0.0/8`) both work. Container platforms that don't pin a
+  single LB egress IP need this; without it the per-IP throttle would
+  collapse into a global one.
+- **CI Docker smoke test.** A second job in the workflow builds the
+  image, boots the container with synthetic env, and curls `/healthz`
+  + `/`. Catches Dockerfile / entrypoint / collectstatic / static-
+  serving regressions the unit tests can't.
+
+### Changed
+
+- **`settings.py` no longer hard-fails when `.env` is missing.**
+  Container-platform deploys inject configuration via `os.environ`;
+  there is no file. `django-environ` reads from the process env when
+  no file is present. The required-vars check below still fails loudly
+  if anything actually needed is unset.
+
 ## [1.2.0] — 2026-05-06
 
 A second polish pass focused on observability, 12-factor configuration,

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,14 +56,24 @@ RUN set -eux; \
 
 # Cache directory for the file-based throttle. Has to be writable at runtime.
 # /app is owned by root after COPY; chown the slots that need writes.
-RUN mkdir -p /app/collateral_provider/.cache /app/collateral_provider/staticfiles \
-    && chown -R app:app /app/collateral_provider/.cache /app/collateral_provider/staticfiles
+# Pre-create /run/keys for the entrypoint's signing-key materialization
+# (the app user can't mkdir under /run, which is root-owned).
+RUN mkdir -p /app/collateral_provider/.cache /app/collateral_provider/staticfiles /run/keys \
+    && chown -R app:app /app/collateral_provider/.cache /app/collateral_provider/staticfiles /run/keys \
+    && chmod 700 /run/keys
 
 USER app
 
 WORKDIR /app/collateral_provider
 
 EXPOSE 8080
+
+# Entrypoint materializes SKEY_CONTENTS / VKEY_CONTENTS env vars to
+# tmpfs files (/run/keys/) before exec'ing gunicorn. Operators using a
+# mounted volume for keys can simply leave those env vars unset — the
+# entrypoint skips the materialization and gunicorn picks up whatever
+# SKEY_PATH / VKEY_PATH point to.
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 
 # Workers: 2-3 is appropriate for a single small instance. The file-based
 # cache backend shares throttle counters across workers on the same host.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1.7
+#
+# Container image for DigitalOcean App Platform (or any container host).
+# Runs gunicorn directly — Whitenoise serves the collected static files
+# from inside the same process, so there is no separate web server.
+#
+# Signing keys are NOT baked in. They must be mounted at runtime via
+# SKEY_PATH / VKEY_PATH (e.g. DO App Platform secret files at /run/...,
+# or a mounted volume). The ApiConfig.ready() check at startup will
+# refuse to boot if they are missing.
+
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+# libsodium isn't strictly required (PyNaCl bundles its own), but build-essential
+# would only be needed if a wheel were missing — every dep in requirements.txt
+# ships manylinux wheels for cpython 3.12, so we can skip the toolchain.
+# curl stays in the image for the health check / smoke test.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Run as a non-root user. App Platform doesn't strictly require it, but it's
+# cheap defence-in-depth: a code-execution bug shouldn't have root inside the
+# container.
+RUN useradd --system --create-home --uid 10001 app
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+# Project layout: manage.py lives at /app/collateral_provider/manage.py.
+# Everything else (known.hosts.json, etc.) lives at /app/.
+COPY . /app/
+
+# Static files for the landing page + DRF browsable API. Collectstatic
+# needs settings.py to import successfully, which means PKH/SECRET_KEY/etc.
+# must parse — pass throwaway values via env (apps.py skips key validation
+# during collectstatic so the dummy SKEY/VKEY paths are fine).
+RUN set -eux; \
+    export PKH=0000000000000000000000000000000000000000000000000000000000000000 \
+           DJANGO_SECRET_KEY=build-time-only-not-a-real-secret \
+           ENVIRONMENT=development \
+           PREPROD_TXID=0000000000000000000000000000000000000000000000000000000000000000 \
+           PREPROD_TXIDX=0 \
+           "PREPROD_NETWORK=--testnet-magic 1" \
+           MAINNET_TXID=0000000000000000000000000000000000000000000000000000000000000000 \
+           MAINNET_TXIDX=0 \
+           MAINNET_NETWORK=--mainnet; \
+    python collateral_provider/manage.py collectstatic --noinput
+
+# Cache directory for the file-based throttle. Has to be writable at runtime.
+# /app is owned by root after COPY; chown the slots that need writes.
+RUN mkdir -p /app/collateral_provider/.cache /app/collateral_provider/staticfiles \
+    && chown -R app:app /app/collateral_provider/.cache /app/collateral_provider/staticfiles
+
+USER app
+
+WORKDIR /app/collateral_provider
+
+EXPOSE 8080
+
+# Workers: 2-3 is appropriate for a single small instance. The file-based
+# cache backend shares throttle counters across workers on the same host.
+# Bind to 8080 because that's the port DO App Platform's HTTP router expects.
+CMD ["gunicorn", "collateral_provider.wsgi:application", \
+     "--bind", "0.0.0.0:8080", \
+     "--workers", "2", \
+     "--access-logfile", "-", \
+     "--error-logfile", "-"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,16 @@ FROM python:3.12-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    # In a container the default file-based debug.log is wrong:
+    # gunicorn's stdout is what the platform captures, /app/collateral_provider/
+    # isn't writable by the unprivileged app user, and any file we did write
+    # would die with the container on restart. Send the rotating handler at
+    # /dev/null and emit JSON-per-line on stdout so log aggregators index
+    # fields cleanly. Operators can override either by setting the env var
+    # in their platform spec.
+    LOG_FILE=/dev/null \
+    LOG_FORMAT=json
 
 # libsodium isn't strictly required (PyNaCl bundles its own), but build-essential
 # would only be needed if a wheel were missing — every dep in requirements.txt

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,8 +58,42 @@ If you're running this service:
       As a code-level safeguard, the service only honors `X-Forwarded-For`
       when the immediate peer (`REMOTE_ADDR`) is in `TRUSTED_PROXY_IPS`
       (default: `127.0.0.1`, `::1`). Set this list to your real proxy
-      egress IPs in multi-host deploys.
+      egress IPs (or CIDR blocks) in multi-host deploys.
 - [ ] Subscribe to the GitHub repository's Dependabot/security alerts.
 - [ ] Pin to a known-good commit (don't deploy from `main` without review).
 - [ ] Probe `/healthz` from your load balancer; it returns 503 if the keys
       become unreadable so traffic gets routed away from a broken host.
+
+### Container-platform deploys (DigitalOcean App Platform, Fly, Render, ...)
+
+If you're using the [DigitalOcean App Platform deploy](docs/DEPLOY.md)
+(or another platform that runs the bundled `Dockerfile`), additional
+hardening:
+
+- [ ] Signing keys must enter the runtime via `SKEY_CONTENTS` /
+      `VKEY_CONTENTS` SECRET env vars (or a mounted volume). They must
+      **never** be baked into the image — `.dockerignore` excludes
+      `api/key/` for exactly this reason. The entrypoint writes them
+      to `/run/keys/` (tmpfs) and unsets the env vars before exec'ing
+      gunicorn.
+- [ ] `DJANGO_SECRET_KEY` must be a real ≥50-char random string set as
+      a SECRET env var; never reuse the dev or CI value in production.
+- [ ] `TRUSTED_PROXY_IPS` must list the platform's load-balancer source
+      ranges (CIDR is supported). Leaving the default (`127.0.0.1`,
+      `::1`) means every request appears to come from the LB's single
+      private IP, which collapses the per-IP throttle into a global
+      throttle — easy to miss, very bad. The bundled `.do/app.yaml`
+      sets the standard RFC1918 ranges, which is correct for App
+      Platform.
+- [ ] `ALLOWED_HOSTS` must include the platform-issued hostname plus
+      your custom domain. An overly permissive value (e.g. `*`) opens
+      Host-header injection.
+- [ ] Verify `/metrics` is either off (default) or restricted to a
+      specific scraper IP via `METRICS_ALLOW_IPS`. The endpoint exposes
+      aggregate request counts and Koios outcomes — not per-user data,
+      but still implementation detail you don't want public.
+- [ ] If you scale beyond `instance_count: 1`, the file-based throttle
+      cache no longer shares state between instances. The throttle
+      becomes per-instance (effective rate = `N * COLLATERAL_THROTTLE_RATE`).
+      Either keep `instance_count: 1` or wire in a shared cache (e.g.
+      DO Managed Redis + `django-redis`) before scaling.

--- a/collateral_provider/api/tests/test_views.py
+++ b/collateral_provider/api/tests/test_views.py
@@ -210,3 +210,36 @@ class TestClientIp(TestCase):
             REMOTE_ADDR="::1",
         )
         self.assertEqual(_client_ip(request), "2001:db8::1")
+
+    def test_cidr_block_in_trusted_proxies_is_honored(self):
+        # Container platforms (DO App Platform, etc.) source LB traffic
+        # from a private range rather than a single pinned IP. Listing
+        # the CIDR rather than every individual IP must Just Work.
+        request = self.factory.post(
+            "/",
+            HTTP_X_FORWARDED_FOR="1.2.3.4",
+            REMOTE_ADDR="10.42.7.99",
+        )
+        with override_settings(TRUSTED_PROXY_IPS=["10.0.0.0/8"]):
+            self.assertEqual(_client_ip(request), "1.2.3.4")
+
+    def test_remote_addr_outside_cidr_is_not_trusted(self):
+        request = self.factory.post(
+            "/",
+            HTTP_X_FORWARDED_FOR="1.2.3.4",
+            REMOTE_ADDR="8.8.8.8",
+        )
+        with override_settings(TRUSTED_PROXY_IPS=["10.0.0.0/8"]):
+            self.assertEqual(_client_ip(request), "8.8.8.8")
+
+    def test_invalid_cidr_entry_is_skipped_not_fatal(self):
+        # An operator typo in TRUSTED_PROXY_IPS should not 500 every
+        # request; the bad entry is logged and ignored, the valid one
+        # still works.
+        request = self.factory.post(
+            "/",
+            HTTP_X_FORWARDED_FOR="1.2.3.4",
+            REMOTE_ADDR="127.0.0.1",
+        )
+        with override_settings(TRUSTED_PROXY_IPS=["not-an-ip", "127.0.0.1"]):
+            self.assertEqual(_client_ip(request), "1.2.3.4")

--- a/collateral_provider/api/views.py
+++ b/collateral_provider/api/views.py
@@ -1,6 +1,8 @@
+import ipaddress
 import json
 import logging
 import os
+from functools import lru_cache
 from typing import ClassVar
 
 from django.conf import settings
@@ -56,6 +58,38 @@ def _load_known_hosts() -> dict:
     return _known_hosts_loader().get()
 
 
+@lru_cache(maxsize=1)
+def _trusted_proxy_networks(entries: tuple[str, ...]) -> tuple[ipaddress._BaseNetwork, ...]:
+    """Parse TRUSTED_PROXY_IPS once into ip_network objects so the per-request
+    membership check is cheap. Bare IPs become single-host networks; CIDR
+    strings (e.g. ``10.0.0.0/8``) become the corresponding network. Invalid
+    entries are dropped with a warning rather than failing the request.
+
+    Container-platform deploys (DigitalOcean App Platform, Fly, Render, ...)
+    can't pin a single LB IP, but the container's REMOTE_ADDR is always
+    inside the platform's private network — listing the relevant private
+    CIDRs lets the throttle key off real client IPs again.
+    """
+    nets = []
+    for entry in entries:
+        try:
+            nets.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError:
+            logger.warning("Ignoring invalid TRUSTED_PROXY_IPS entry: %r", entry)
+    return tuple(nets)
+
+
+def _is_trusted_proxy(remote: str | None) -> bool:
+    if not remote:
+        return False
+    try:
+        peer = ipaddress.ip_address(remote)
+    except ValueError:
+        return False
+    networks = _trusted_proxy_networks(tuple(settings.TRUSTED_PROXY_IPS))
+    return any(peer in net for net in networks)
+
+
 def _client_ip(request) -> str | None:
     """Best-effort client IP extraction.
 
@@ -64,10 +98,14 @@ def _client_ip(request) -> str | None:
     REMOTE_ADDR directly — a client connecting to gunicorn without the
     proxy in front can't spoof their source IP and bypass the per-IP
     throttle just by setting an X-Forwarded-For header.
+
+    Entries in TRUSTED_PROXY_IPS may be bare IPs (``127.0.0.1``) or CIDR
+    blocks (``10.0.0.0/8``). The latter is needed on container platforms
+    that don't pin a single load-balancer IP.
     """
     remote = request.META.get("REMOTE_ADDR")
     xff = request.META.get("HTTP_X_FORWARDED_FOR")
-    if xff and remote in settings.TRUSTED_PROXY_IPS:
+    if xff and _is_trusted_proxy(remote):
         return xff.split(",")[0].strip()
     return remote
 

--- a/collateral_provider/collateral_provider/settings.py
+++ b/collateral_provider/collateral_provider/settings.py
@@ -111,6 +111,11 @@ MIDDLEWARE = [
     'api.middleware.RequestIDMiddleware',     # stamp X-Request-ID before anything logs
     'api.middleware.MetricsMiddleware',       # measure /collateral request count + duration
     'django.middleware.security.SecurityMiddleware',
+    # Whitenoise serves the collected static files directly from gunicorn.
+    # Required because containerized deploys (DO App Platform, etc.) don't
+    # have a separate static-file server in front. Must sit immediately
+    # after SecurityMiddleware per Whitenoise docs.
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -279,3 +284,19 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),  # This is your static folder
 ]
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+# Whitenoise: gzip/brotli-compress the collected static assets so the
+# wire bytes are small. We do NOT use the manifest variant (which would
+# hash filenames) because it requires `collectstatic` to have run before
+# anything renders a `{% static %}` tag — that breaks the test suite,
+# which doesn't run collectstatic. The static surface here is tiny
+# (favicons + DRF browsable-API CSS) so the cache-busting story is fine
+# without filename hashing.
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'whitenoise.storage.CompressedStaticFilesStorage',
+    },
+}

--- a/collateral_provider/collateral_provider/settings.py
+++ b/collateral_provider/collateral_provider/settings.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from pathlib import Path
 
 import environ
@@ -11,16 +10,16 @@ from api import __version__ as API_VERSION
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Initialize environment variables
-env_file = os.path.join(BASE_DIR, '.env')
-
-# Check if the .env file exists
-if not os.path.exists(env_file):
-    print(f"Error: .env file is missing at {env_file}. Exiting.")
-    sys.exit(1)  # Exit the application with a non-zero status code
-
+# Configuration is read from process environment, with a .env file as an
+# optional convenience for local development. Container-platform deploys
+# (DigitalOcean App Platform, Heroku-style PaaS, Kubernetes) inject
+# variables directly via os.environ — there is no .env file in those
+# environments, and that is fine. The required-vars check below still
+# fails loudly if anything actually needed is unset.
 env = environ.Env()
-environ.Env.read_env(env_file)
+env_file = os.path.join(BASE_DIR, '.env')
+if os.path.exists(env_file):
+    environ.Env.read_env(env_file)
 
 # Identity / signing material. Both key paths default to the api/key dir
 # bundled with the repo (used in dev and tests); production deploys should

--- a/collateral_provider/sample.env
+++ b/collateral_provider/sample.env
@@ -69,7 +69,11 @@ MAINNET_NETWORK=--mainnet
 # METRICS_ALLOW_IPS=127.0.0.1,::1,10.0.0.5
 
 # X-Forwarded-For is only trusted if the request's immediate peer is one
-# of these IPs. Defaults to localhost (right when nginx/Caddy is on the
-# same host as gunicorn). Multi-host deploys list every load-balancer or
-# reverse-proxy egress IP. An empty list disables XFF trust entirely.
+# of these IPs. Each entry is either a bare IP (127.0.0.1) or a CIDR
+# block (10.0.0.0/8) — the latter is what container platforms like
+# DigitalOcean App Platform need, since their load-balancer egress isn't
+# a single pinned IP. Defaults to localhost (right when nginx/Caddy is
+# on the same host as gunicorn). An empty list disables XFF trust
+# entirely.
 # TRUSTED_PROXY_IPS=127.0.0.1,::1
+# TRUSTED_PROXY_IPS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Container entrypoint.
+#
+# Materializes signing keys onto a tmpfs path if they were supplied via
+# encrypted env vars (the common DigitalOcean App Platform pattern):
+#
+#   SKEY_CONTENTS=<full JSON of payment.skey>
+#   VKEY_CONTENTS=<full JSON of payment.vkey>
+#
+# If those env vars are unset the script does nothing — whatever
+# SKEY_PATH / VKEY_PATH the operator configured (e.g. a mounted volume)
+# is used as-is.
+#
+# Why a tmpfs path: the materialized files live under /run, which is a
+# tmpfs on most container runtimes; they do not persist across container
+# restarts and are not written to the image layers.
+
+set -eu
+
+KEYDIR=/run/keys
+mkdir -p "$KEYDIR"
+
+if [ -n "${SKEY_CONTENTS:-}" ]; then
+    umask 077
+    printf '%s' "$SKEY_CONTENTS" > "$KEYDIR/payment.skey"
+    SKEY_PATH="$KEYDIR/payment.skey"
+    export SKEY_PATH
+    unset SKEY_CONTENTS
+fi
+
+if [ -n "${VKEY_CONTENTS:-}" ]; then
+    umask 077
+    printf '%s' "$VKEY_CONTENTS" > "$KEYDIR/payment.vkey"
+    VKEY_PATH="$KEYDIR/payment.vkey"
+    export VKEY_PATH
+    unset VKEY_CONTENTS
+fi
+
+exec "$@"

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,200 @@
+# Deploying to DigitalOcean App Platform
+
+This is the one-time setup for the App Platform deploy. Once it's wired
+up, every push to `main` rebuilds the image and rolls it out — no SSH,
+no `systemctl restart`.
+
+For local development setup, see [README.md](../README.md). This file
+is operator-facing.
+
+## Prerequisites
+
+- A DigitalOcean account with billing enabled.
+- `doctl` installed and authenticated (`doctl auth init`).
+- The repo's collateral signing keys (`payment.skey`, `payment.vkey`)
+  on your local disk. They will be uploaded to DO's encrypted secret
+  store; they will not enter the repo or the container image.
+- A 50-character random string for `DJANGO_SECRET_KEY`. Easiest:
+  ```bash
+  python3 -c 'import secrets; print(secrets.token_urlsafe(50))'
+  ```
+
+## One-time setup
+
+### 1. Edit `.do/app.yaml`
+
+Open [.do/app.yaml](../.do/app.yaml) and replace every
+`REPLACE_WITH_...` sentinel with the real value:
+
+| Field | What to paste |
+| --- | --- |
+| `PKH` | The PKH derived from your `payment.vkey` |
+| `DJANGO_SECRET_KEY` | The 50-char random string from above |
+| `SKEY_CONTENTS` | The **entire contents** of `payment.skey` (it's a single-line JSON: `{"type":"...","description":"...","cborHex":"..."}`) |
+| `VKEY_CONTENTS` | The entire contents of `payment.vkey` |
+| `PREPROD_TXID`, `PREPROD_TXIDX` | The collateral UTxO you've funded on preprod |
+| `MAINNET_TXID`, `MAINNET_TXIDX` | The collateral UTxO you've funded on mainnet |
+| `ALLOWED_HOSTS` | After step 2, paste the DO-issued hostname here, plus your custom domain if you have one |
+
+The `github.repo` field assumes
+`logical-mechanism/Collateral-Provider`. If you're deploying a fork,
+update it.
+
+> ⚠️ The `value:` next to a `type: SECRET` env var goes into DO's
+> encrypted store the moment you submit the spec. It is **not**
+> retrievable afterwards — only updatable. Keep your local copy of
+> the spec out of git history (the file is tracked but the
+> placeholders are sentinels — don't commit a spec with the secrets
+> filled in).
+
+### 2. Create the app
+
+```bash
+doctl apps create --spec .do/app.yaml
+```
+
+App Platform will:
+1. Clone the repo at `main`.
+2. Build the Docker image from `Dockerfile`.
+3. Boot the container, wait for `/healthz` to return 200, then route
+   traffic to it.
+
+The first build typically takes 4–6 minutes. Watch progress:
+
+```bash
+doctl apps list
+doctl apps get <app-id>
+doctl apps logs <app-id> --type build --follow
+```
+
+Once live, the app gets a hostname like
+`collateral-provider-abc12.ondigitalocean.app`. Update `ALLOWED_HOSTS`
+in `.do/app.yaml` to include it (without the scheme), then push the
+update:
+
+```bash
+doctl apps update <app-id> --spec .do/app.yaml
+```
+
+### 3. Verify the deploy
+
+```bash
+# Healthcheck (note: the app's hostname, not your custom domain)
+curl -fsS https://<app-hostname>/healthz
+
+# Real signing request (preprod, with a real preprod tx CBOR)
+python3 scripts/py/query.py preprod <hex-tx-cbor>
+```
+
+If `/healthz` returns 503, the signing keys probably didn't materialize
+correctly. `doctl apps logs <app-id> --type run` will show the boot-time
+error from `ApiConfig.ready()`.
+
+### 4. Optional: custom domain
+
+In the App Platform web console:
+1. Add your domain under **Settings → Domains**.
+2. Update your DNS to the `CNAME` DO provides.
+3. DO provisions a free Let's Encrypt cert.
+4. Add the domain to `ALLOWED_HOSTS` in `.do/app.yaml` and push the
+   spec.
+
+## Day-2 operations
+
+### Updating env vars
+
+Edit `.do/app.yaml`, then:
+
+```bash
+doctl apps update <app-id> --spec .do/app.yaml
+```
+
+This triggers a rolling redeploy with the new values. Existing requests
+finish on the old container before traffic shifts.
+
+### Rotating the signing keys
+
+1. Generate a new key pair on a host that's not the App Platform
+   instance.
+2. Fund a new collateral UTxO under the new PKH.
+3. Update `SKEY_CONTENTS`, `VKEY_CONTENTS`, `PKH`,
+   `PREPROD_TXID`/`MAINNET_TXID` in `.do/app.yaml` simultaneously.
+4. `doctl apps update --spec`. App Platform rolls the new keys in;
+   the old container drains. Brief race window where the listed
+   collateral UTxO doesn't match the listed PKH is unavoidable —
+   schedule rotation off-peak.
+
+### Rolling back
+
+App Platform retains previous deploys. Roll back via:
+
+```bash
+doctl apps list-deployments <app-id>
+doctl apps create-deployment <app-id> --force-rebuild=false \
+    --rollback-to <previous-deployment-id>
+```
+
+Or in the web console: **Activity** → click a previous deploy →
+**Redeploy this version**.
+
+### Editing the ban list / known-hosts registry
+
+Two paths, depending on whether you opted into the persistent volume in
+`.do/app.yaml`:
+
+- **Default (no volume).** `bans.json` and `known.hosts.json` live
+  inside the image. Edit the files in the repo, commit, push to `main`.
+  DO rebuilds and rolls out the new content.
+
+- **With volume.** Files live on the mounted `/data/` volume.
+  ```bash
+  doctl apps console <app-id> -c web
+  $ vi /data/bans.json
+  $ exit
+  ```
+  The next request reads the new file (mtime-aware reload). No restart
+  required.
+
+### Scraping `/metrics`
+
+Off by default. To turn on, add to `.do/app.yaml`:
+
+```yaml
+- key: METRICS_ENABLED
+  value: "True"
+- key: METRICS_ALLOW_IPS
+  value: 127.0.0.1,::1,<your-scraper-private-ip>
+```
+
+The scraper must be on a network App Platform considers "private" to
+hit it — typically a same-VPC droplet. From the public internet,
+`/metrics` 404s by design.
+
+### Scaling
+
+The current spec runs one `basic-xxs` instance. To scale:
+
+- **Vertically.** Bump `instance_size_slug` to `basic-xs` / `basic-s`.
+- **Horizontally.** Increase `instance_count`. ⚠️ The file-based
+  cache backend (used by the throttle) is *per-instance* — at
+  `instance_count > 1` the per-IP throttle counts independently per
+  worker, so the effective rate is `N * COLLATERAL_THROTTLE_RATE`.
+  Switch to a Redis-backed cache (`django-redis`, attach a DO Managed
+  Redis) before relying on horizontal scaling.
+
+## What's where on the deployed instance
+
+```
+/app/                                  WORKDIR root, owned by the app user
+  collateral_provider/
+    manage.py
+    .cache/                            file-based throttle cache (writable)
+    staticfiles/                       collected by collectstatic at build
+    api/
+      key/                             EMPTY — keys land at /run/keys/
+    bans.json                          baked into image (or /data/bans.json)
+    known.hosts.json (parent dir)      baked into image (or /data/known.hosts.json)
+/run/keys/                             tmpfs, populated by docker-entrypoint.sh
+  payment.skey                         from $SKEY_CONTENTS
+  payment.vkey                         from $VKEY_CONTENTS
+```

--- a/docs/DO_INTEGRATION_PROMPT.md
+++ b/docs/DO_INTEGRATION_PROMPT.md
@@ -1,0 +1,248 @@
+# Prompt: DigitalOcean App Platform integration
+
+Paste this into a fresh Claude Code session. The branch `do-app-platform`
+is already created and checked out at the tip of `main`; the v1.2.0 work
+(modernization, observability, hot-reloadable config, OpenAPI, /healthz,
+/metrics, JSON logging) has just merged.
+
+---
+
+## Brief
+
+The Collateral-Provider repo at `/home/logic/Documents/LogicalMechanism/Collateral-Provider`
+currently runs on a single droplet with manually-managed gunicorn. Updates
+require SSHing in and bouncing the service. We want **push-to-`main` →
+DigitalOcean App Platform rebuilds and serves the new version** — no SSH
+required.
+
+Work on the existing `do-app-platform` branch (already created from `main`).
+At the end, open a PR back to `main`.
+
+## Read these first
+
+- `CLAUDE.md` — repo orientation. The "Operational extras" section
+  matters most.
+- `CHANGELOG.md` — the just-merged 1.1.0 + 1.2.0 entries explain every
+  config knob and endpoint.
+- `collateral_provider/sample.env` — every env var the service reads.
+- `SECURITY.md` — operator hardening checklist (TLS proxy, ALLOWED_HOSTS,
+  TRUSTED_PROXY_IPS, key locations).
+- `.github/workflows/ci.yml` — pattern for synthesizing dummy signing
+  keys on a fresh runner.
+- `collateral_provider/api/apps.py` — startup key validation.
+
+## Hard constraints
+
+These are non-negotiable per the project's design choices:
+
+1. **Signing keys are local-only.** `payment.skey` / `payment.vkey` must
+   never enter the repo, the container image, or any Git artifact. They
+   are uploaded by the operator to DigitalOcean's encrypted secrets
+   (or mounted as a volume) at deploy time. CI uses all-zero dummies;
+   prod uses the real ones from DO's secret store.
+2. **No user tracking, no audit logging.** Don't add anything that
+   persists per-request data tied to a user/IP/tx. Aggregated metrics
+   (already in place via `/metrics`) are fine.
+3. **No API keys / no per-user auth.** It stays an open anon API.
+4. **Single host today, but the deploy shape should not preclude scaling
+   later.** File-based `.cache/` is fine for now, but document where it
+   would need to move (Redis/Memcached) if scaled out.
+
+## Known gotchas (real things that will bite you)
+
+These came up during the v1.2.0 work and are easy to miss:
+
+1. **`settings.py` sys.exit(1) if `.env` is missing.** DO sets env vars
+   at the platform level, not via a file. Either:
+   - Make the `.env` file check optional when the env vars it would have
+     set are already present, **or**
+   - Have the entrypoint synthesize a `.env` from process env vars
+     before starting Django.
+   The first is cleaner. `django-environ` is happy reading from
+   `os.environ` directly when no file is present.
+
+2. **`api/apps.py` `ApiConfig.ready()` validates signing keys at
+   startup** and refuses to boot if they're missing. That's a feature in
+   prod (loud failure) but be aware: the container won't start if the
+   skey/vkey aren't mounted/available before `manage.py runserver` /
+   `gunicorn` runs. The check is skipped during `test` /
+   `collectstatic` / `makemigrations` (see the `sys.argv` gate).
+
+3. **`bans.json` and `known.hosts.json` are hot-reloadable from disk.**
+   On DO App Platform, the container filesystem is ephemeral —
+   modifications inside the running container don't survive a restart
+   or re-deploy. Three options, pick one and document it:
+   - **Bake into image**: include `bans.json` and `known.hosts.json` at
+     build time. Edits require a redeploy. Loses the hot-reload property.
+   - **Persistent volume**: DO App Platform supports volumes. Mount one
+     at `/data/` and set `BANS_PATH=/data/bans.json`,
+     `KNOWN_HOSTS_PATH=/data/known.hosts.json`. Operator edits via
+     `doctl apps console` or by uploading a new file via the volume.
+   - **Fetch at startup from external storage** (e.g. DO Spaces or
+     a small admin endpoint). Most flexible, more moving parts.
+   Recommendation: persistent volume. `known.hosts.json` already lives
+   at the repo root — could ship a default copy in the image and
+   override via the volume if present.
+
+4. **`SECRET_KEY`** must be a real value, not committed. Use DO's
+   encrypted env var support.
+
+5. **`ALLOWED_HOSTS`** must include the DO-provided hostname
+   (`<app>-<hash>.ondigitalocean.app`) plus any custom domain.
+   `ALLOWED_HOSTS=` empty → app refuses to start (by design).
+
+6. **`TRUSTED_PROXY_IPS`** — DO's load balancer is the immediate peer.
+   Either:
+   - Add DO's load-balancer egress IPs to this list, **or**
+   - Set it to a wildcard pattern, **or**
+   - Leave the default (`127.0.0.1`, `::1`) — XFF won't be trusted, so
+     the throttle will key off DO's LB IP for everyone, which means
+     **the per-IP throttle becomes a global throttle**. That's bad.
+   Look up DO App Platform's documented egress IPs and configure.
+
+7. **Static files.** `STATIC_ROOT = staticfiles/`. The container needs a
+   `collectstatic` step at build time AND something to serve those files
+   in production. Easiest: add `whitenoise` to `requirements.in` and
+   `WhiteNoiseMiddleware` right after `SecurityMiddleware`.
+
+8. **Health probe**. DO supports a custom HTTP health check. Use
+   `GET /healthz`, expect 200. (Already implemented and unthrottled.)
+
+9. **TLS** is terminated at DO's edge. `SECURE_PROXY_SSL_HEADER` is
+   already set correctly.
+
+10. **JSON logging**: set `LOG_FORMAT=json` so DO's log aggregator
+    indexes fields cleanly. Set `LOG_FILE=/dev/null` or similar so the
+    rotating file handler doesn't fight the container's stdout — or
+    better, swap the file handler for a stream handler in production
+    (one more setting to drive from env).
+
+11. **Database**. The current `DATABASES['default']` uses sqlite
+    `:memory:`. We have no models, so this is effectively a no-op. DO
+    App Platform asks if you want a managed Postgres — say no.
+
+12. **Workers and memory**. Default gunicorn `workers = 2 *
+    cpu_count() + 1`. For a $5 droplet–size DO instance, set workers to
+    2–3 explicitly. The `.cache` file backend works across workers on
+    one host; if multi-host scaling becomes real, switch to Redis
+    (deferred per current design).
+
+## Acceptance criteria
+
+You're done when all of these are true:
+
+1. Pushing to `main` triggers a DO App Platform rebuild that completes
+   without manual intervention. The new image becomes live and the old
+   one is drained.
+2. The deployed app responds 200 to `GET /healthz` from a public test.
+3. The deployed app accepts a real `POST /preprod/collateral/` and
+   returns a witness — using the operator's real signing keys, which
+   were uploaded to DO once at setup and are never in Git.
+4. The collateral-throttle correctly identifies different client IPs
+   (i.e., XFF trust is configured to honor DO's LB header).
+5. `/metrics` is reachable from a configured scraper IP and 404s from
+   anywhere else.
+6. Logs in DO's panel are JSON-shaped and include `request_id` for
+   correlation.
+7. CI on the `do-app-platform` branch is green (the existing test suite
+   plus any new tests you add).
+
+## Suggested deliverables
+
+In rough commit order:
+
+1. **`Dockerfile`** at the repo root. Multi-stage if it makes the image
+   smaller; otherwise a single stage is fine. Python 3.12 base.
+   Installs `requirements.txt`, runs `collectstatic`, runs gunicorn.
+   Handles the case where signing keys are mounted at a non-default
+   path via `SKEY_PATH` / `VKEY_PATH`.
+
+2. **`settings.py` change**: stop hard-failing on missing `.env`. If
+   `.env` exists, read it; otherwise rely on `os.environ` directly.
+   Keep `sys.exit(1)` for missing required vars (PKH, DJANGO_SECRET_KEY,
+   ENVIRONMENT, network configs).
+
+3. **`whitenoise` integration** for static-file serving inside the
+   container. Add to `requirements.in`, recompile, add the middleware,
+   set `STATICFILES_STORAGE` if compressed serving is wanted.
+
+4. **`.do/app.yaml`** (DO App Platform spec). Defines the service:
+   build command, run command, health check path, env vars (with
+   `value_type: SECRET` for sensitive ones), persistent volume mount
+   for `bans.json` + `known.hosts.json` if going that route.
+
+5. **`docs/DEPLOY.md`** (or a section in README) — operator-facing
+   one-time setup steps:
+   - `doctl apps create --spec .do/app.yaml` (or via web console)
+   - Setting required env vars (which ones, where to get values)
+   - Uploading signing keys (which method)
+   - Pointing the custom domain
+   - How to roll back
+
+6. **A small Docker smoke test** — script or CI step that builds the
+   image, runs it with synthetic env, curls `/healthz`, asserts 200.
+   Something like:
+   ```yaml
+   - name: Docker smoke test
+     run: |
+       docker build -t collateral-provider:ci .
+       docker run -d --name app -p 8000:8000 \
+         -e PKH=... -e DJANGO_SECRET_KEY=... [...] \
+         collateral-provider:ci
+       sleep 5
+       curl -f http://localhost:8000/healthz
+   ```
+
+7. **CHANGELOG entry** under `[Unreleased]` documenting the deploy
+   shape change.
+
+8. **Don't forget**: update `SECURITY.md` operator checklist with the
+   DO-specific hardening (TRUSTED_PROXY_IPS for DO's LB, secret
+   storage, volume permissions).
+
+## Out of scope
+
+Don't do these in this branch — they're separate efforts:
+
+- Migrating signing keys outside `api/key/` for the legacy single-host
+  deploy (deferred per memory/project_deferred_work.md).
+- Switching cache backend to Redis (premature; current scale doesn't
+  need it).
+- Adding observability beyond what's already in place (`/metrics`,
+  request IDs, JSON logs, /healthz).
+
+## Workflow expectations
+
+- Run `./test.sh` after each substantive change. Suite is ~129 tests,
+  ~50ms.
+- Run `./lint.sh` before committing.
+- Each commit is a coherent unit (Dockerfile alone, settings change
+  alone, etc.) with a body explaining the *why*.
+- Don't combine unrelated changes.
+- If something requires a tradeoff (volume vs. baked-in for bans.json,
+  for example), surface it in the chat before committing — don't make
+  the call silently.
+- When in doubt about DO-specific behavior, look up the docs rather
+  than guessing.
+
+## How to verify you're not done
+
+Easy ways to fool yourself into thinking you're done when you're not:
+
+- Local Docker build succeeds. (Doesn't prove DO build works — they
+  have different defaults, e.g. read-only filesystem layers.)
+- `/healthz` responds 200 locally. (Doesn't prove signing keys are
+  reachable in the deployed container.)
+- A git push happened. (Doesn't prove DO actually picked it up. Check
+  the DO panel.)
+- Tests pass. (They're stubs that mock signing-key locations and the
+  Koios call. Don't catch deploy-pipeline issues.)
+
+Verify the deploy by:
+- Looking at DO's build logs after a real push
+- `curl -f https://<deployed-host>/healthz` from outside DO
+- A real signing request with a real preprod tx (use scripts/py/query.py)
+- Checking metrics scrape from your configured allow-listed IP
+
+Good luck. Ask the user before making any decision that touches their
+production traffic — domain transfers, env-var values, secret rotation.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -171,6 +171,8 @@ werkzeug==3.1.8
     #   locust
 wheel==0.47.0
     # via pip-tools
+whitenoise==6.12.0
+    # via -r requirements.in
 wsproto==1.3.2
     # via simple-websocket
 zope-event==6.2

--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,4 @@ requests~=2.32
 prometheus-client~=0.21
 
 gunicorn~=23.0
+whitenoise~=6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,3 +74,5 @@ uritemplate==4.2.0
     # via drf-spectacular
 urllib3==2.6.3
     # via requests
+whitenoise==6.12.0
+    # via -r requirements.in


### PR DESCRIPTION
## Summary

- Bundles a one-command DO App Platform deploy: `Dockerfile` + `docker-entrypoint.sh` + `.do/app.yaml`. Push to `main` → DO rebuilds the image and rolls it out behind their TLS-terminating router. No SSH.
- Signing keys enter the runtime as `SKEY_CONTENTS` / `VKEY_CONTENTS` SECRET env vars and are materialized to `/run/keys/` (tmpfs) by the entrypoint. `api/key/` is in `.dockerignore` so the real keys never enter the image.
- `whitenoise` serves static files in-process so the container needs no separate web server.
- `TRUSTED_PROXY_IPS` now accepts CIDR blocks. **This is load-bearing** — the existing exact-IP match would silently collapse the per-IP throttle into a global one on DO, since the LB egress isn't a single pinned IP.
- `settings.py` no longer hard-fails when `.env` is missing (DO injects config via `os.environ`). Required-vars checks below still fail loudly.

Operator runbook in [`docs/DEPLOY.md`](docs/DEPLOY.md). Container-platform hardening in [`SECURITY.md`](SECURITY.md).

No HTTP-contract change — this is `[Unreleased]` not a version bump.

## Test plan

- [x] 132 unit tests pass (3 new for CIDR matching: in-block, out-of-block, typo-tolerance)
- [x] `ruff` clean
- [x] OpenAPI schema validates
- [ ] CI green on this branch (the new `docker` job will build the image, boot the container with synthetic env, and curl `/healthz` + `/`)
- [ ] Real DO deploy: edit `.do/app.yaml` placeholders → `doctl apps create --spec .do/app.yaml` → `curl https://<host>/healthz` returns 200 → `scripts/py/query.py preprod <real-tx>` returns a witness

🤖 Generated with [Claude Code](https://claude.com/claude-code)