### PR TITLE
entrypoint: accept bare cborHex for SKEY_CONTENTS / VKEY_CONTENTS

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,8 +4,15 @@
 # Materializes signing keys onto a tmpfs path if they were supplied via
 # encrypted env vars (the common DigitalOcean App Platform pattern):
 #
-#   SKEY_CONTENTS=<full JSON of payment.skey>
-#   VKEY_CONTENTS=<full JSON of payment.vkey>
+#   SKEY_CONTENTS=<full JSON of payment.skey, OR just the cborHex value>
+#   VKEY_CONTENTS=<full JSON of payment.vkey, OR just the cborHex value>
+#
+# The "just the cborHex value" form (e.g. 5820abc...def) exists because
+# DO App Platform's spec parser treats `{` / `}` as template syntax and
+# rejects pasted JSON with errors like 'Unexpected "}" at <pos>'. If
+# the value starts with `{` we trust it's full JSON and write it as-is;
+# otherwise we treat it as a bare cborHex string and wrap it in the
+# minimal Cardano-CLI envelope get_key_from_file() expects.
 #
 # If those env vars are unset the script does nothing — whatever
 # SKEY_PATH / VKEY_PATH the operator configured (e.g. a mounted volume)
@@ -20,17 +27,35 @@ set -eu
 KEYDIR=/run/keys
 mkdir -p "$KEYDIR"
 
-if [ -n "${SKEY_CONTENTS:-}" ]; then
+write_key() {
+    # $1 = env var content, $2 = output path, $3 = JSON `type` field used
+    # when wrapping a bare cborHex value.
+    contents="$1"
+    out="$2"
+    keytype="$3"
     umask 077
-    printf '%s' "$SKEY_CONTENTS" > "$KEYDIR/payment.skey"
+    case "$contents" in
+        '{'*)
+            printf '%s' "$contents" > "$out"
+            ;;
+        *)
+            printf '{"type":"%s","description":"","cborHex":"%s"}' \
+                "$keytype" "$contents" > "$out"
+            ;;
+    esac
+}
+
+if [ -n "${SKEY_CONTENTS:-}" ]; then
+    write_key "$SKEY_CONTENTS" "$KEYDIR/payment.skey" \
+        "PaymentSigningKeyShelley_ed25519"
     SKEY_PATH="$KEYDIR/payment.skey"
     export SKEY_PATH
     unset SKEY_CONTENTS
 fi
 
 if [ -n "${VKEY_CONTENTS:-}" ]; then
-    umask 077
-    printf '%s' "$VKEY_CONTENTS" > "$KEYDIR/payment.vkey"
+    write_key "$VKEY_CONTENTS" "$KEYDIR/payment.vkey" \
+        "PaymentVerificationKeyShelley_ed25519"
     VKEY_PATH="$KEYDIR/payment.vkey"
     export VKEY_PATH
     unset VKEY_CONTENTS


### PR DESCRIPTION
## Summary

DigitalOcean App Platform's spec parser treats `{` / `}` as template delimiters and rejects pasted Cardano-CLI key JSON with errors like `Unexpected "}" at 159`. The original entrypoint only accepted the full JSON envelope, so the DO setup flow had to fight that.

The entrypoint now inspects the first character of `SKEY_CONTENTS` / `VKEY_CONTENTS`:
- starts with `{` → treat as full JSON (existing flow)
- otherwise → treat as a bare `cborHex` value (`5820...`) and wrap it in the minimal envelope `get_key_from_file()` expects

Operators can now `jq -r .cborHex payment.skey` and paste the result directly. No braces, no template-syntax fight.

## Test plan

- [ ] CI green (existing smoke test still uses the JSON form, so it covers the existing path)
- [ ] On DO, paste the `cborHex` string into `SKEY_CONTENTS` / `VKEY_CONTENTS`. Deploy comes up. `/healthz` returns 200. A real preprod tx returns a witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)