### PR TITLE
Optional additional_utxos pass-through to Ogmios evaluateTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ HTTP contract:
 
 ### Added
 
+- **Optional `additional_utxos` request field.** Forwarded to Ogmios as
+  [`additionalUtxo`](https://ogmios.dev/mini-protocols/local-tx-submission/#additional-utxo-set)
+  on the `evaluateTransaction` call, so callers can splice in
+  `[txin, txout]` pairs that don't yet exist on chain (chained-tx /
+  future-input scenarios). Missing or empty is skipped silently;
+  non-empty is forwarded verbatim — the inner Ogmios UTxO shape isn't
+  mirrored here, so a malformed entry surfaces as the standard
+  `Transaction Fails Validation` 400 from Koios's verdict, not as our
+  bug.
+
+### Added
+
 - **Container-platform deploy shape.** [`Dockerfile`](Dockerfile),
   [`docker-entrypoint.sh`](docker-entrypoint.sh), and
   [`.do/app.yaml`](.do/app.yaml) bundle a one-command DigitalOcean App

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ A Django + DRF service that takes a Cardano transaction CBOR from a user, valida
 The whole product is one main endpoint plus operational extras:
 
 ```
-POST /<environment>/collateral/   body: { "tx_body": "<hex cbor>" }   -> { "witness": "<hex cbor>" }
+POST /<environment>/collateral/   body: { "tx": "<hex cbor>", "additional_utxos"?: [[txin, txout], ...] }   -> { "witness": "<hex cbor>" }
 GET  /healthz                                                          -> { "status": "ok", "version": "..." }
 GET  /known_hosts/                                                     -> registry JSON
 GET  /                                                                 -> landing HTML

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ POST /<environment>/collateral/   { "tx": "<hex cbor>" }   →   { "witness": "<
 The historical request field name `tx_body` is still accepted as a
 deprecated alias and will be removed in a future major release.
 
+An optional `additional_utxos` field on the request is forwarded to Ogmios
+as [`additionalUtxo`](https://ogmios.dev/mini-protocols/local-tx-submission/#additional-utxo-set)
+so script evaluation can see UTxOs from a transaction not yet on chain.
+Each entry is a `[txin, txout]` pair in Ogmios's shape; the field is
+skipped when missing or empty. Inner shape isn't mirrored here — if
+Ogmios doesn't like an entry, you get the standard `Transaction Fails
+Validation` 400.
+
 Validation pipeline (cheap to expensive — first failure short-circuits the rest):
 
 1. Banned IP / unknown environment

--- a/collateral_provider/api/serializers.py
+++ b/collateral_provider/api/serializers.py
@@ -18,8 +18,12 @@ logger = logging.getLogger("api")
 
 
 class ProvideCollateralSerializer(serializers.Serializer):
-    """The request body has one field, ``tx``, holding the full transaction
-    CBOR (body + witness set + is_valid + auxiliary data) hex-encoded.
+    """The request body has one required field, ``tx``, holding the full
+    transaction CBOR (body + witness set + is_valid + auxiliary data)
+    hex-encoded. An optional ``additional_utxos`` field carries extra
+    ``[txin, txout]`` pairs that get forwarded verbatim to Ogmios as
+    ``additionalUtxo`` so script evaluation can see UTxOs created by
+    transactions not yet on chain.
 
     For one transition release we also accept the historical name
     ``tx_body`` as an alias — that name was misleading because the value
@@ -30,6 +34,21 @@ class ProvideCollateralSerializer(serializers.Serializer):
     """
 
     tx = serializers.CharField(allow_blank=False, trim_whitespace=True)
+    # Loose by design: we don't mirror Ogmios's full UTxO schema here.
+    # The list is forwarded verbatim if non-empty, omitted otherwise.
+    # If individual entries are malformed, Koios returns a real verdict
+    # ("Transaction Fails Validation") rather than us spending effort to
+    # match shape upstream might evolve.
+    additional_utxos = serializers.ListField(
+        required=False,
+        allow_empty=True,
+        child=serializers.JSONField(),
+        help_text=(
+            "Optional list of [txin, txout] pairs spliced into the chain "
+            "state for script evaluation. Forwarded to Ogmios as "
+            "`additionalUtxo`. Missing or empty is fine — skipped."
+        ),
+    )
 
     LEGACY_FIELD = "tx_body"
 
@@ -75,7 +94,20 @@ class ProvideCollateralSerializer(serializers.Serializer):
         check_collateral(body, env_settings)
         check_signers(body, settings.PKH)
 
+        # Pull additional_utxos straight from raw input — the field is
+        # declared on the serializer (so it shows up in OpenAPI) but we
+        # don't trust DRF's per-field validation order to have it ready
+        # by the time validate_tx runs. Anything that isn't a non-empty
+        # list is skipped, matching the "missing or incomplete = ignore"
+        # contract.
+        raw_extra = (
+            self.initial_data.get("additional_utxos")
+            if isinstance(self.initial_data, dict)
+            else None
+        )
+        additional_utxos = raw_extra if isinstance(raw_extra, list) and raw_extra else None
+
         # Most expensive check last: it's a remote HTTP call.
-        check_valid_tx(tx_cbor, environment)
+        check_valid_tx(tx_cbor, environment, additional_utxos=additional_utxos)
 
         return tx_cbor

--- a/collateral_provider/api/simulate.py
+++ b/collateral_provider/api/simulate.py
@@ -22,6 +22,7 @@ class UpstreamUnavailable(Exception):
 def evaluate_transaction(
     tx_body_cbor_hex: str,
     environment: str,
+    additional_utxos: list | None = None,
     timeout: float | tuple[float, float] = DEFAULT_TIMEOUT,
 ) -> dict:
     """Submit the tx CBOR to Koios for script-evaluation simulation.
@@ -37,6 +38,13 @@ def evaluate_transaction(
     errors, timeouts, 5xx, and non-JSON bodies become ``UpstreamUnavailable``
     (which the view layer translates to a 503).
 
+    ``additional_utxos`` (Ogmios's ``additionalUtxo``) lets the caller
+    splice extra ``[txin, txout]`` pairs into the chain state Ogmios uses
+    to evaluate scripts — useful for transactions that depend on UTxOs
+    created by an as-yet-unsubmitted prior tx. We forward it verbatim if
+    non-empty; the inner shape isn't mirrored or validated here, so a
+    malformed entry surfaces as a Koios-side rejection, not an outage.
+
     The endpoint URL is taken from
     ``settings.ENVIRONMENTS[<env>]['KOIOS_URL']`` so operators can
     self-host Koios or use alternate networks (preview, sanchonet)
@@ -48,10 +56,13 @@ def evaluate_transaction(
         raise UpstreamUnavailable(f"unknown environment: {environment}")
 
     url = env_settings["KOIOS_URL"]
+    params: dict = {"transaction": {"cbor": tx_body_cbor_hex}}
+    if additional_utxos:
+        params["additionalUtxo"] = additional_utxos
     payload = {
         "jsonrpc": "2.0",
         "method": "evaluateTransaction",
-        "params": {"transaction": {"cbor": tx_body_cbor_hex}},
+        "params": params,
     }
     headers = {
         "accept": "application/json",

--- a/collateral_provider/api/tests/test_additional_utxos.py
+++ b/collateral_provider/api/tests/test_additional_utxos.py
@@ -1,0 +1,92 @@
+"""Optional ``additional_utxos`` request field.
+
+Forwards to Ogmios as ``additionalUtxo`` so script evaluation can see UTxOs
+created by transactions not yet on chain. Per-design: missing or empty is
+fine and skipped silently; non-empty is forwarded verbatim — Koios returns
+a real verdict if the inner shape is wrong, which surfaces to the caller as
+a normal `Transaction Fails Validation` 400.
+"""
+
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from api.tests.test_views import build_happy_path_tx_cbor
+
+
+def _sample_extra_utxo() -> list:
+    return [
+        [
+            {"transaction": {"id": "a" * 64}, "index": 0},
+            {
+                "address": "addr_test1qz...",
+                "value": {"ada": {"lovelace": 1_500_000}},
+            },
+        ]
+    ]
+
+
+@override_settings(ALLOWED_HOSTS=["testserver"])
+class TestAdditionalUtxosPassThrough(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("collateral", kwargs={"environment": "preprod"})
+
+    def tearDown(self):
+        cache.clear()
+
+    @patch("api.validators.transaction.evaluate_transaction")
+    def test_field_absent_means_no_additional_utxos_forwarded(self, mock_eval):
+        mock_eval.return_value = {"jsonrpc": "2.0", "result": []}
+        response = self.client.post(
+            self.url, {"tx": build_happy_path_tx_cbor()}, format="json"
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(mock_eval.call_args.kwargs.get("additional_utxos"), None)
+
+    @patch("api.validators.transaction.evaluate_transaction")
+    def test_empty_list_is_treated_as_skip(self, mock_eval):
+        mock_eval.return_value = {"jsonrpc": "2.0", "result": []}
+        response = self.client.post(
+            self.url,
+            {"tx": build_happy_path_tx_cbor(), "additional_utxos": []},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        # An empty list is "incomplete" — skipped, never reaches Koios.
+        self.assertEqual(mock_eval.call_args.kwargs.get("additional_utxos"), None)
+
+    @patch("api.validators.transaction.evaluate_transaction")
+    def test_non_empty_list_forwarded_verbatim(self, mock_eval):
+        mock_eval.return_value = {"jsonrpc": "2.0", "result": []}
+        extra = _sample_extra_utxo()
+        response = self.client.post(
+            self.url,
+            {"tx": build_happy_path_tx_cbor(), "additional_utxos": extra},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(mock_eval.call_args.kwargs.get("additional_utxos"), extra)
+
+    @patch("api.validators.transaction.evaluate_transaction")
+    def test_malformed_inner_entry_is_still_passed_through(self, mock_eval):
+        # Per design we do not mirror Ogmios's UTxO schema. If the user
+        # sends an inner shape that's wrong, Koios returns a real verdict
+        # and the request 400s with our standard tx-fails-validation message.
+        mock_eval.return_value = {
+            "jsonrpc": "2.0",
+            "error": {"code": -32602, "message": "Bad UTxO"},
+        }
+        response = self.client.post(
+            self.url,
+            {
+                "tx": build_happy_path_tx_cbor(),
+                "additional_utxos": [["only-one-element-instead-of-pair"]],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn("Transaction Fails Validation", response.json()["detail"])

--- a/collateral_provider/api/tests/test_simulate.py
+++ b/collateral_provider/api/tests/test_simulate.py
@@ -69,6 +69,37 @@ class TestEvaluateTransaction(unittest.TestCase):
         self.assertEqual(sent_json["jsonrpc"], "2.0")
         self.assertEqual(sent_json["method"], "evaluateTransaction")
         self.assertEqual(sent_json["params"]["transaction"]["cbor"], "cafebabe")
+        # additionalUtxo only appears when the caller provided one.
+        self.assertNotIn("additionalUtxo", sent_json["params"])
+
+    @patch("api.simulate.requests.post")
+    def test_additional_utxos_forwarded_as_additionalUtxo(self, mock_post):
+        mock_post.return_value = _mock_response(200, {"result": []})
+        extra = [
+            [
+                {"transaction": {"id": "ab" * 32}, "index": 0},
+                {"address": "addr_test1...", "value": {"ada": {"lovelace": 1_000_000}}},
+            ]
+        ]
+        evaluate_transaction("cafebabe", "preprod", additional_utxos=extra)
+        params = mock_post.call_args.kwargs["json"]["params"]
+        self.assertEqual(params["additionalUtxo"], extra)
+
+    @patch("api.simulate.requests.post")
+    def test_empty_additional_utxos_omitted_from_payload(self, mock_post):
+        mock_post.return_value = _mock_response(200, {"result": []})
+        evaluate_transaction("cafebabe", "preprod", additional_utxos=[])
+        self.assertNotIn(
+            "additionalUtxo", mock_post.call_args.kwargs["json"]["params"]
+        )
+
+    @patch("api.simulate.requests.post")
+    def test_none_additional_utxos_omitted_from_payload(self, mock_post):
+        mock_post.return_value = _mock_response(200, {"result": []})
+        evaluate_transaction("cafebabe", "preprod", additional_utxos=None)
+        self.assertNotIn(
+            "additionalUtxo", mock_post.call_args.kwargs["json"]["params"]
+        )
 
     @patch("api.simulate.requests.post")
     def test_passes_timeout_to_requests(self, mock_post):

--- a/collateral_provider/api/tests/validators/test_transaction.py
+++ b/collateral_provider/api/tests/validators/test_transaction.py
@@ -16,7 +16,23 @@ class TestTransactionValidator(unittest.TestCase):
         # Koios accepted the tx — response includes a 'result' key.
         mock_eval.return_value = {"jsonrpc": "2.0", "result": []}
         check_valid_tx("deadbeef", "preprod")
-        mock_eval.assert_called_once_with("deadbeef", "preprod")
+        mock_eval.assert_called_once_with(
+            "deadbeef", "preprod", additional_utxos=None
+        )
+
+    @patch("api.validators.transaction.evaluate_transaction")
+    def test_additional_utxos_forwarded_when_provided(self, mock_eval):
+        mock_eval.return_value = {"jsonrpc": "2.0", "result": []}
+        extra = [
+            [
+                {"transaction": {"id": "ab" * 32}, "index": 0},
+                {"address": "addr_test1...", "value": {"ada": {"lovelace": 1_000_000}}},
+            ]
+        ]
+        check_valid_tx("deadbeef", "preprod", additional_utxos=extra)
+        mock_eval.assert_called_once_with(
+            "deadbeef", "preprod", additional_utxos=extra
+        )
 
     @patch("api.validators.transaction.evaluate_transaction")
     def test_invalid_tx_raises_validation_error(self, mock_eval):

--- a/collateral_provider/api/validators/transaction.py
+++ b/collateral_provider/api/validators/transaction.py
@@ -14,13 +14,23 @@ class UpstreamServiceUnavailable(APIException):
     default_code = "upstream_unavailable"
 
 
-def check_valid_tx(tx_body_cbor: str, environment: str) -> None:
+def check_valid_tx(
+    tx_body_cbor: str,
+    environment: str,
+    additional_utxos: list | None = None,
+) -> None:
     """Ask Koios to evaluate the transaction. A response with a 'result' key
     means the tx is structurally and economically valid; anything else means
     it would be rejected by the chain. Network/upstream failures surface as
-    503 instead of being misreported as a bad-tx 400."""
+    503 instead of being misreported as a bad-tx 400.
+
+    ``additional_utxos`` is forwarded as Ogmios's ``additionalUtxo`` —
+    optional extra ``[txin, txout]`` pairs spliced into the chain state for
+    script evaluation. Pass-through; not inspected here."""
     try:
-        response = evaluate_transaction(tx_body_cbor, environment)
+        response = evaluate_transaction(
+            tx_body_cbor, environment, additional_utxos=additional_utxos
+        )
     except UpstreamUnavailable as exc:
         logger.error(f"Upstream Evaluation Unavailable: {exc}")
         raise UpstreamServiceUnavailable() from exc

--- a/collateral_provider/api/views.py
+++ b/collateral_provider/api/views.py
@@ -159,6 +159,28 @@ class ProvideCollateralThrottle(throttling.AnonRateThrottle):
                 request_only=True,
             ),
             OpenApiExample(
+                "Sample request with additional_utxos",
+                value={
+                    "tx": "84a900d901028182582000...f5f6",
+                    "additional_utxos": [
+                        [
+                            {"transaction": {"id": "ab" * 32}, "index": 0},
+                            {
+                                "address": "addr_test1qz...",
+                                "value": {"ada": {"lovelace": 1500000}},
+                            },
+                        ],
+                    ],
+                },
+                request_only=True,
+                description=(
+                    "Optional `additional_utxos` is forwarded to Ogmios as "
+                    "`additionalUtxo` so script evaluation can see UTxOs "
+                    "from a transaction not yet on chain. Missing or empty "
+                    "is fine — the field is skipped."
+                ),
+            ),
+            OpenApiExample(
                 "Sample success",
                 value={"witness": "8200825820...5840..."},
                 response_only=True,


### PR DESCRIPTION
## Summary

Adds an optional `additional_utxos` field on the collateral request that gets forwarded as Ogmios's [`additionalUtxo`](https://ogmios.dev/mini-protocols/local-tx-submission/#additional-utxo-set) on the `evaluateTransaction` JSON-RPC call. Lets callers splice in `[txin, txout]` pairs that don't yet exist on chain — the chained-tx / future-input scenario.

The field is **pass-through**: missing or empty is skipped, non-empty is forwarded verbatim. We deliberately don't mirror Ogmios's UTxO schema here. If a caller sends a malformed entry, Koios returns a real verdict and the request 400s with our standard `Transaction Fails Validation` message.

### Safety

A bogus `additional_utxos` can't trick the service into losing collateral:

- A tx that references a UTxO not actually on chain fails phase-1 → no script execution → no collateral spent.
- The only path to collateral consumption via this field is a script-failing tx where the attacker also pays the collateral consumption — i.e. self-attack, no value.

## Changes

- `simulate.evaluate_transaction` accepts `additional_utxos`, adds `additionalUtxo` to params iff truthy.
- `validators.transaction.check_valid_tx` forwards the value.
- `serializers.ProvideCollateralSerializer` declares the field (so it appears in the OpenAPI schema), but reads from `initial_data` and applies the simple "non-empty list, otherwise skip" sanitizer in `validate_tx`.
- OpenAPI: new request example showing the shape.
- README + CHANGELOG updated. CLAUDE.md request-line updated.

## Test plan

- [x] 140 tests pass (8 new across `test_simulate`, `test_transaction`, and a new `test_additional_utxos` for view-level coverage)
- [x] `ruff` clean
- [x] OpenAPI schema validates
- [ ] Manual: deployed instance accepts a real preprod tx with `additional_utxos` referencing a UTxO from a not-yet-submitted prior tx, returns a witness; tx submits successfully on chain after the prior tx lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)