### PR TITLE
landing page polish + descriptive field-error messages

### DIFF
--- a/collateral_provider/api/templates/api/landing.html
+++ b/collateral_provider/api/templates/api/landing.html
@@ -13,40 +13,273 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="{% static 'android-chrome-512x512.png' %}">
     <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'apple-touch-icon.png' %}">
+    <link rel="manifest" href="{% static 'site.webmanifest' %}">
     <title>Cardano Collateral Provider</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #fafaf7;
+            --surface: #ffffff;
+            --surface-2: #f3f2ec;
+            --border: #e6e3d9;
+            --text: #1c1c1a;
+            --text-muted: #5b5b55;
+            --accent: #b3007a;
+            --accent-hover: #870059;
+            --code-bg: #f3f2ec;
+            --shadow: 0 1px 2px rgba(20, 20, 20, 0.04);
+        }
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #14140f;
+                --surface: #1c1c18;
+                --surface-2: #232320;
+                --border: #2e2e29;
+                --text: #ececea;
+                --text-muted: #9b9b94;
+                --accent: #ff5fb8;
+                --accent-hover: #ff8acc;
+                --code-bg: #0f0f0c;
+                --shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+            }
+        }
+        * { box-sizing: border-box; }
+        html, body { margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.55;
+            -webkit-font-smoothing: antialiased;
+        }
+        .wrap {
+            max-width: 760px;
+            margin: 0 auto;
+            padding: 3.5rem 1.5rem 4rem;
+        }
+        header { margin-bottom: 2.5rem; }
+        .eyebrow {
+            font-size: 0.78rem;
+            text-transform: uppercase;
+            letter-spacing: 0.12em;
+            color: var(--accent);
+            font-weight: 600;
+            margin: 0 0 0.6rem;
+        }
+        h1 {
+            font-size: 1.95rem;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            margin: 0 0 0.6rem;
+        }
+        .lede {
+            font-size: 1.05rem;
+            color: var(--text-muted);
+            margin: 0;
+            max-width: 56ch;
+        }
+        section { margin-top: 2.25rem; }
+        h2 {
+            font-size: 0.78rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--text-muted);
+            font-weight: 600;
+            margin: 0 0 0.85rem;
+        }
+        .card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1rem 1.1rem;
+            box-shadow: var(--shadow);
+        }
+        .card + .card { margin-top: 0.6rem; }
+        .pkh {
+            font-family: "SF Mono", "Menlo", "Consolas", monospace;
+            font-size: 0.84rem;
+            color: var(--text);
+            word-break: break-all;
+            background: var(--code-bg);
+            padding: 0.75rem 0.9rem;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            display: block;
+        }
+        .net {
+            display: flex;
+            flex-direction: column;
+            gap: 0.55rem;
+        }
+        .net-head {
+            display: flex;
+            align-items: center;
+            gap: 0.55rem;
+        }
+        .net-name {
+            font-weight: 600;
+            font-size: 0.95rem;
+            text-transform: capitalize;
+        }
+        .badge {
+            font-size: 0.7rem;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            padding: 0.15rem 0.45rem;
+            border-radius: 999px;
+            background: var(--surface-2);
+            color: var(--text-muted);
+            border: 1px solid var(--border);
+        }
+        .row {
+            display: flex;
+            gap: 0.5rem;
+            font-size: 0.82rem;
+            align-items: baseline;
+            flex-wrap: wrap;
+        }
+        .row .k {
+            color: var(--text-muted);
+            min-width: 4rem;
+        }
+        .row .v {
+            font-family: "SF Mono", "Menlo", "Consolas", monospace;
+            color: var(--text);
+            word-break: break-all;
+            flex: 1;
+        }
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 1px solid transparent;
+            transition: border-color 120ms ease, color 120ms ease;
+        }
+        a:hover { color: var(--accent-hover); border-bottom-color: currentColor; }
+        pre {
+            background: var(--code-bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 0.85rem 1rem;
+            overflow-x: auto;
+            font-family: "SF Mono", "Menlo", "Consolas", monospace;
+            font-size: 0.82rem;
+            margin: 0;
+            color: var(--text);
+        }
+        code { font-family: "SF Mono", "Menlo", "Consolas", monospace; font-size: 0.9em; }
+        ul.links {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        ul.links li + li { margin-top: 0.4rem; }
+        ul.links a {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+        ul.links a::after {
+            content: "→";
+            color: var(--text-muted);
+            transition: transform 120ms ease;
+        }
+        ul.links a:hover::after { transform: translateX(2px); color: var(--accent); }
+        .notice {
+            color: var(--text-muted);
+            font-size: 0.9rem;
+            background: var(--surface-2);
+            border: 1px dashed var(--border);
+            border-radius: 6px;
+            padding: 0.75rem 0.9rem;
+        }
+        footer {
+            margin-top: 4rem;
+            padding-top: 1.5rem;
+            border-top: 1px solid var(--border);
+            color: var(--text-muted);
+            font-size: 0.82rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+        footer .ver { font-family: "SF Mono", "Menlo", "Consolas", monospace; }
+    </style>
 </head>
 <body>
-    <header>
-        <h1>Cardano Collateral Provider</h1>
-    </header>
-    <main>
+    <div class="wrap">
+        <header>
+            <p class="eyebrow">Cardano · Altruistic Collateral</p>
+            <h1>Shared collateral, signed on demand.</h1>
+            <p class="lede">
+                Build a transaction that uses this provider's collateral UTxO and PKH,
+                POST the CBOR, and get back a vkey witness to attach before submitting
+                on chain. No wallet collateral, no Blockfrost key, no full node required.
+            </p>
+        </header>
+
         <section>
-            <h2>Required Signer Hash:</h2>
-            <p>{{ pkh }}</p>
+            <h2>Required Signer Hash</h2>
+            <code class="pkh">{{ pkh }}</code>
         </section>
+
         <section>
-            <h2>Available Networks:</h2>
-            <pre>{{ networks_json }}</pre>
+            <h2>Available Networks</h2>
+            {% if networks %}
+                {% for net in networks %}
+                <div class="card net">
+                    <div class="net-head">
+                        <span class="net-name">{{ net.name }}</span>
+                        <span class="badge">collateral</span>
+                    </div>
+                    {% if net.url %}
+                    <div class="row">
+                        <span class="k">Endpoint</span>
+                        <span class="v"><a href="{{ net.url }}">{{ net.url }}</a></span>
+                    </div>
+                    {% endif %}
+                    {% if net.utxo_id %}
+                    <div class="row">
+                        <span class="k">UTxO</span>
+                        <span class="v">{{ net.utxo_id }}#{{ net.utxo_idx }}</span>
+                    </div>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            {% else %}
+                <div class="notice">
+                    {% if registered %}
+                        This provider is registered but no networks are configured.
+                    {% else %}
+                        This provider's PKH is not yet listed in
+                        <code>known.hosts.json</code>. Open a PR to register it.
+                    {% endif %}
+                </div>
+            {% endif %}
         </section>
+
+        <section>
+            <h2>Quick start</h2>
+            <pre>curl -X POST {{ request.scheme }}://{{ request.get_host }}/&lt;network&gt;/collateral/ \
+     -H 'Content-Type: application/json' \
+     -d '{ "tx": "&lt;hex cbor&gt;" }'</pre>
+        </section>
+
         <section>
             <h2>Resources</h2>
-            <ul>
-                <li>
-                    <a href="https://github.com/logical-mechanism/Collateral-Provider?tab=readme-ov-file#example-use" target="_blank" rel="noopener noreferrer">
-                        View GitHub for Example Use
-                    </a>
-                </li>
-                <li>
-                    <a href="/known_hosts/">View Known Collateral Providers</a>
-                </li>
-                <li>
-                    <a href="/api/docs/">API Documentation</a>
-                </li>
+            <ul class="links">
+                <li><a href="https://github.com/logical-mechanism/Collateral-Provider?tab=readme-ov-file#example-use" rel="noopener noreferrer">GitHub &amp; example use</a></li>
+                <li><a href="/known_hosts/">Known collateral providers</a></li>
+                <li><a href="/api/docs/">API documentation</a></li>
             </ul>
         </section>
-    </main>
-    <footer>
-        <p>Created By Logical Mechanism LLC With ❤️</p>
-    </footer>
+
+        <footer>
+            <span>Created by Logical Mechanism LLC</span>
+            <span class="ver">v{{ version }}</span>
+        </footer>
+    </div>
 </body>
 </html>

--- a/collateral_provider/api/tests/test_data_reload.py
+++ b/collateral_provider/api/tests/test_data_reload.py
@@ -165,7 +165,14 @@ class TestKnownHostsHotReload(TestCase):
     def test_landing_page_picks_up_new_hosts(self):
         from django.conf import settings as live_settings
 
-        _write_json(self.path, {live_settings.PKH: {"preprod": "v1"}})
+        def _entry(url):
+            return {
+                live_settings.PKH: {
+                    "preprod": {"url": url, "utxo": {"id": "ab" * 32, "idx": 0}},
+                },
+            }
+
+        _write_json(self.path, _entry("https://example.test/v1/collateral/"))
         _bump_mtime(self.path)
 
         with override_settings(KNOWN_HOSTS_PATH=self.path):
@@ -173,7 +180,7 @@ class TestKnownHostsHotReload(TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertIn(b"v1", response.content)
 
-            _write_json(self.path, {live_settings.PKH: {"preprod": "v2"}})
+            _write_json(self.path, _entry("https://example.test/v2/collateral/"))
             _bump_mtime(self.path)
 
             response = self.client.get("/")

--- a/collateral_provider/api/tests/test_error_envelope.py
+++ b/collateral_provider/api/tests/test_error_envelope.py
@@ -62,8 +62,29 @@ class TestErrorEnvelope(TestCase):
         self.assertEqual(body["detail"], "Validation Service Unavailable")
 
     def test_no_field_names_leak_in_400_response(self):
-        # The most important reason for normalization: the response shouldn't
-        # leak our internal serializer field names ("tx") to clients.
+        # The response envelope must always be {"detail": "..."} — never a
+        # field-keyed dict. The detail MESSAGE may name the field (it's part
+        # of the public request contract and helps clients debug); what
+        # matters is that the top-level shape is canonical.
         response = self.client.post(self.url, {"tx": "not-hex"}, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertNotIn("tx", response.json())
+        body = response.json()
+        self.assertEqual(set(body.keys()), {"detail"})
+
+    def test_missing_required_field_names_the_field(self):
+        # DRF's default "This field is required." is undebuggable from the
+        # wire — clients can't tell which field they forgot. Pin the
+        # rephrased version so the next regression is obvious.
+        response = self.client.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"detail": "Missing required field: 'tx'"})
+
+    def test_null_field_names_the_field(self):
+        response = self.client.post(self.url, {"tx": None}, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"detail": "Field 'tx' may not be null"})
+
+    def test_blank_field_names_the_field(self):
+        response = self.client.post(self.url, {"tx": ""}, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"detail": "Field 'tx' may not be blank"})

--- a/collateral_provider/api/util.py
+++ b/collateral_provider/api/util.py
@@ -35,9 +35,11 @@ def normalize_error_response(exc, context):
 
     DRF's default returns {field: [msg]} for serializer validation errors and
     {"detail": msg} for everything else. Clients shouldn't have to handle
-    both shapes, especially since the field names would leak our internal
-    structure. Surface the first human-readable message under "detail"
-    and call it a day.
+    both shapes. We collapse to the canonical shape and, for field-keyed
+    errors, fold the field name into the message — DRF's defaults like
+    "This field is required." are otherwise undebuggable from the response
+    alone. The public field name (e.g. ``tx``) is part of the documented
+    request contract; surfacing it in the message isn't a leak.
     """
     response = drf_exception_handler(exc, context)
     if response is None:
@@ -48,5 +50,19 @@ def normalize_error_response(exc, context):
         # Already in the canonical shape — pass through.
         return response
 
-    response.data = {"detail": _first_message(data)}
+    if isinstance(data, dict) and data:
+        field, value = next(iter(data.items()))
+        message = _first_message(value)
+        if field == "non_field_errors":
+            response.data = {"detail": message}
+        elif message == "This field is required.":
+            response.data = {"detail": f"Missing required field: '{field}'"}
+        elif message == "This field may not be null.":
+            response.data = {"detail": f"Field '{field}' may not be null"}
+        elif message == "This field may not be blank.":
+            response.data = {"detail": f"Field '{field}' may not be blank"}
+        else:
+            response.data = {"detail": f"{field}: {message}"}
+    else:
+        response.data = {"detail": _first_message(data)}
     return response

--- a/collateral_provider/api/views.py
+++ b/collateral_provider/api/views.py
@@ -336,11 +336,33 @@ def landing_page(request):
     can confirm they're talking to the right provider, plus the network
     config from known.hosts.json keyed by that PKH."""
     hosts = _load_known_hosts()
-    networks = hosts.get(settings.PKH, "Public Key Hash Not Found In Known Hosts")
+    entry = hosts.get(settings.PKH)
+    # Extract the network -> {utxo, url} mapping for the friendly cards;
+    # ``public_key`` lives at the same depth but isn't a network. Fall
+    # back to an empty list so the template can render an explicit
+    # "not registered" notice rather than a confusing empty section.
+    networks = []
+    if isinstance(entry, dict):
+        for name, cfg in entry.items():
+            if name == "public_key" or not isinstance(cfg, dict):
+                continue
+            utxo = cfg.get("utxo") or {}
+            networks.append({
+                "name": name,
+                "url": cfg.get("url", ""),
+                "utxo_id": utxo.get("id", ""),
+                "utxo_idx": utxo.get("idx", 0),
+            })
     return render(
         request,
         "api/landing.html",
-        {"pkh": settings.PKH, "networks_json": json.dumps(networks, indent=4)},
+        {
+            "pkh": settings.PKH,
+            "networks": networks,
+            "registered": isinstance(entry, dict),
+            "version": settings.SPECTACULAR_SETTINGS["VERSION"],
+            "raw_networks_json": json.dumps(entry or {}, indent=2),
+        },
     )
 
 


### PR DESCRIPTION
## Summary

Two small, independent improvements bundled on one branch:

1. **Landing page rewrite.** The old page was a header + raw JSON dump that didn't say what the service was. New page leads with a one-paragraph lede explaining the workflow, renders each network as a friendly card (name, endpoint URL, UTxO ref) instead of pretty-printed JSON, falls back to a "not registered — open a PR" notice when the PKH isn't in `known.hosts.json`, and ships a curl quick-start block + version stamp in the footer. Inline CSS only, no JS, system font stack, dark mode via `prefers-color-scheme`.

2. **Descriptive field-error messages.** DRF's defaults (`This field is required.`, `This field may not be null.`, `This field may not be blank.`) are undebuggable from the response body alone — a client that POSTs `{}` or accidentally sends `{"tx_body": ...}` sees `"This field is required."` with no hint as to which field. `normalize_error_response` now folds the field name into the message for those three cases:

   | Request | Response |
   | --- | --- |
   | `{}` or `{"tx_body":...}` | `Missing required field: 'tx'` |
   | `{"tx": null}` | `Field 'tx' may not be null` |
   | `{"tx": ""}` | `Field 'tx' may not be blank` |

   Existing Title-Case validator messages and `non_field_errors` are unchanged; the envelope shape stays `{"detail": "<string>"}`. The field name `tx` is part of the documented request contract, so surfacing it in the message isn't a leak.

Motivation for #2: a deployed client (GivemeMyProvider) was hitting `400 {"detail": "This field is required."}` with no signal in DO logs to diagnose which field. After this change the response itself names the field.

## Test plan

- [x] `manage.py test` — 155 passing
- [x] `ruff check` — clean
- [x] Live spot-check of new error messages against `runserver`
- [x] Production smoke against `https://www.giveme.my` confirmed `{"tx":...}` already works on v1.2.0; only client-side shape mismatches produced the original error
- [ ] Visual check of the new landing page in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)