### PR TITLE
Revert instance_count to 1 (basic-xxs cap)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -34,10 +34,11 @@ services:
     # signatures, 16 KiB max payload), so basic-xxs is enough — bump
     # only if /metrics shows actual saturation.
     instance_size_slug: basic-xxs
-    # Two instances so health-check replacements and deploys don't drop
-    # in-flight requests onto a single recycling container. With one
-    # instance, any health-flap window surfaces to the user as 504s.
-    instance_count: 2
+    # basic-xxs is capped at instance_count: 1 by DO. To run two
+    # instances (so health-check replacements don't drop in-flight
+    # requests onto a single recycling container), move up to
+    # basic-xs / professional-xs.
+    instance_count: 1
 
     http_port: 8080
 


### PR DESCRIPTION
## Summary

DO's API rejects \`instance_count: 2\` on \`basic-xxs\`:

\`\`\`
must not exceed 1 instance for instance_size_slug basic-xxs
\`\`\`

The spec from #25 wasn't applyable as-is. Reverting that one line so \`doctl apps update --spec .do/app.yaml\` succeeds; left a comment noting the slug constraint so we don't loop on this later.

The rest of #25 is unaffected and already applied to the live app — Session pooling, gunicorn keep-alive, looser health-check thresholds. To get the second instance we'd need to move up to \`basic-xs\` or \`professional-xs\`.

## Test plan

- [x] \`doctl apps update <id> --spec .do/app.yaml\` succeeds (verified live)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)