### PR TITLE
Route django.request logger through console + file

### DIFF
--- a/collateral_provider/collateral_provider/settings.py
+++ b/collateral_provider/collateral_provider/settings.py
@@ -293,6 +293,14 @@ LOGGING = {
             'level': 'WARNING',
             'propagate': False,
         },
+        # Django's default django.request logger only routes to mail_admins
+        # and propagate=False, so unhandled 500s vanish when ADMINS is empty.
+        # Route it through our handlers so tracebacks reach stderr/the log.
+        'django.request': {
+            'handlers': ['file', 'console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
     },
 }
 


### PR DESCRIPTION
## Summary

Unhandled 500s in production are not surfacing in \`doctl apps logs\` because Django's default \`django.request\` logger has \`propagate: False\` and only ships to a \`mail_admins\` handler. With no \`ADMINS\` configured, every traceback vanishes silently — which is exactly why we couldn't see the cause of the current /collateral 500s.

This PR explicitly configures \`django.request\` to use our \`file\` + \`console\` handlers, matching the pattern of the other loggers in the LOGGING dict.

## Test plan

- [ ] Merge & wait for auto-deploy
- [ ] Trigger a /collateral 500 (downstream or curl)
- [ ] \`doctl apps logs <id> --tail 200 --type run --follow | grep -v kube-probe\` should now show \`Traceback (most recent call last):\` for the failing request

🤖 Generated with [Claude Code](https://claude.com/claude-code)